### PR TITLE
Updated the tab list so that the clicked tab has the "active" class

### DIFF
--- a/src/tab-list/tab-list.component.ts
+++ b/src/tab-list/tab-list.component.ts
@@ -5,6 +5,7 @@ const SELECTOR: string = 'tab-list';
 export interface ITab {
   title: string;
   route: string;
+  class?: string;
 }
 
 @Component({
@@ -15,4 +16,11 @@ export interface ITab {
 
 export class TabListComponent {
   @Input() tabs: ITab[] = [];
+
+  setActive(myTab: ITab){
+    for(let tab of this.tabs){
+      tab.class = '';
+    }
+    myTab.class = 'active';
+  }
 }

--- a/src/tab-list/tab-list.html
+++ b/src/tab-list/tab-list.html
@@ -1,7 +1,7 @@
 <div class="tabNav">
   <ul class="tabNav__tabs">
     <li *ngFor="let tab of tabs" class="tabNav__tabItem" role="presentation">
-      <a [routerLink]="tab.route" class="tabNav__link" role="tab" aria-selected="true" tabindex="0">{{tab.title}}</a>
+      <a [routerLink]="tab.route" class="tabNav__link" [ngClass]="tab.class" role="tab" (click)="setActive(tab)" aria-selected="true" tabindex="0">{{tab.title}}</a>
     </li>
   </ul>
 </div>

--- a/testing/package.json
+++ b/testing/package.json
@@ -26,7 +26,7 @@
     "zone.js": "^0.8.14"
   },
   "devDependencies": {
-    "@angular/cli": "1.6.6",
+    "@angular/cli": "1.6.3",
     "@angular/compiler-cli": "4.0.0",
     "@angular/language-service": "4.0.0",
     "@types/jasmine": "~2.5.53",


### PR DESCRIPTION
Needed the clicked tab to have an "active" class so that it could be styled effectively.

NOTE:  I changed the CLI back to 1.6.3 because it was breaking on 1.6.6.  I can take this change out of the merge if you want. 